### PR TITLE
Prepare to cut release 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 services:
   - docker
@@ -11,7 +12,7 @@ env:
     # REGISTRY_PASS=
     - secure: "D4I4uElXOoNfyCDeoOFGo3MqW0KdyI7jFmWisgrQrB2QN2cgeVQNWow0RF5TujApJrHM2p36YTFQI7tSy3Jp7EaqWj1Zf/L1mHhgbbbvTyrry/XaZ/Aa2j+yQrFGhdnuf4PDUw6ws1j94h1IhU1jdDvDIyFsX5QFZFMd/A9QUAwgPAC39I52zGDOnORCpRI4FKzF3MgV6IpmsIKMCT5uFo3A5F7jPBk62fU3bNMfS31KXMK5KW1XEzQQTTzbzmudDQhoKPNSqCJYx3FZK2RP2WOLge6wVWBQHhxsx6WwKlEdTgfgt1OVkYMMBCJMEvCNfcAqVqT8z/QJPgrWAgTwFx8Pjeklk43cX/s1JLMLMBGZe9OX6Q1dXKoTuRKfbJMqptL7jEaCfCdmG9MmOioJselbs++h0OX3xAQEv6r9zcs5V5lEUp1tDysRFsJ0jxpoPW5M0c61M0B3MCdrPrjpv3/QdZ2zZnTyXoqs7dTWs7o7jfOExEfgVZt4SOP5wAXL2azlwZmO/crm5lbeecVZGiW0ak2jRfdqWO/Zy26tdDkFa2L8XHhjccJ8fBHsWBcNl28E81FuN0DoLZJuqiJqIiPcVC546NOMPKnJxhaR5FlGGDwFjH0+RaAFqIAQa0KC6En37R8d1S515v9SECQQ0gUH7PU6GIVAytfx0G8tl/4="
 python:
-  - "3.6"
+  - "3.7"
 before_install:
   - sudo curl -L https://github.com/aelsabbahy/goss/releases/download/v$GOSS_VERSION/goss-linux-amd64 -o /usr/local/bin/goss
   - sudo curl -L https://github.com/aelsabbahy/goss/releases/download/v$GOSS_VERSION/dgoss -o /usr/local/bin/dgoss

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.1.0
 
+ * [security] Rebuild image using latest upstream python:3.7-alpine tag to fix CVE-2019-5021 (#7)
  * [dependencies] Bump twisted from 18.9.0 to 19.2.1 (#6)
 
 # 1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.0
+
+ * [dependencies] Bump twisted from 18.9.0 to 19.2.1 (#6)
+
 # 1.0.0
 
  * Expose four metrics from the filesystem:


### PR DESCRIPTION
* Upgrade Python used by Travis to 3.7 (ie. the same version as that packaged with the application in its Dockerfile)
* Update changelog

Note that when released this will implicitly rebuild the Docker image using the latest version of python:3.7-alpine, which in turn brings in alpine 3.9.4, thus resolving CVE-2019-5021.