### PR TITLE
fix(docker-build)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /install
 
 COPY requirements.txt /requirements.txt
 
-RUN pip install --install-option="--prefix=/install" -r /requirements.txt
+RUN pip install --prefix=/install -r /requirements.txt
 
 FROM python:3.7-alpine
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 pytest==3.2.5
 pytest-cov==2.5.1
 flake8==2.4.0
-liccheck2==0.1.4
+liccheck==0.4.9
 bandit==1.5.1
 safety==1.8.4
 docker-ci-deploy==0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Twisted==19.7.0
+Twisted==20.3.0
 prometheus_client==0.4.2


### PR DESCRIPTION
build failing with the following message:

```
ERROR: Location-changing options found in --install-option: ['--prefix']
from command line. This is unsupported, use pip-level options like
--user, --prefix, --root, and --target instead.
```